### PR TITLE
FIX: add more animatable camelcase svg attributes to attr set

### DIFF
--- a/src/render/svg/utils/camel-case-attrs.ts
+++ b/src/render/svg/utils/camel-case-attrs.ts
@@ -21,4 +21,8 @@ export const camelCaseAttributes = new Set([
     "tableValues",
     "viewBox",
     "gradientTransform",
+    "startOffset",
+    "textLength",
+    "lengthAdjust",
+    "stitchTiles",
 ])


### PR DESCRIPTION
This should resolve [#1152](https://github.com/framer/motion/issues/1152).